### PR TITLE
Change event name. Fixes #6.

### DIFF
--- a/d2l-search-widget.html
+++ b/d2l-search-widget.html
@@ -120,7 +120,7 @@
 				* when the search field is cleared by the user. The detail of the event is
 				* the search results, which can then be parsed in the handler.
 				*
-				* @event search-results-changed
+				* @event d2l-search-widget-results-changed
 				*/
 
 				/*
@@ -238,7 +238,7 @@
 					var parser = document.createElement('d2l-siren-parser');
 					var searchResponse = parser.parse(response.detail.xhr.response);
 					this.set('searchResults', searchResponse || {});
-					this.fire('search-results-changed', this.searchResults);
+					this.fire('d2l-search-widget-results-changed', this.searchResults);
 				}
 			},
 			_onSearchUrlChanged: function(url) {

--- a/demo/d2l-search-widget-demo.html
+++ b/demo/d2l-search-widget-demo.html
@@ -67,7 +67,7 @@
 			</p>
 
 			<script>
-				document.getElementById('widget').addEventListener('search-results-changed', function(e) {
+				document.getElementById('widget').addEventListener('d2l-search-widget-results-changed', function(e) {
 					var ul = document.getElementById('result');
 					ul.innerHTML = '';
 					e.detail.entities.forEach(function(entity) {
@@ -76,7 +76,7 @@
 						ul.appendChild(li);
 					});
 				});
-				document.getElementById('manual-search').addEventListener('search-results-changed', function(e) {
+				document.getElementById('manual-search').addEventListener('d2l-search-widget-results-changed', function(e) {
 					var ul = document.getElementById('manual-search-result');
 					ul.innerHTML = '';
 					e.detail.entities.forEach(function(entity) {
@@ -85,7 +85,7 @@
 						ul.appendChild(li);
 					});
 				});
-				document.getElementById('small-search').addEventListener('search-results-changed', function(e) {
+				document.getElementById('small-search').addEventListener('d2l-search-widget-results-changed', function(e) {
 					var ul = document.getElementById('small-search-result');
 					ul.innerHTML = '';
 					e.detail.entities.forEach(function(entity) {

--- a/test/d2l-search-widget.html
+++ b/test/d2l-search-widget.html
@@ -76,7 +76,7 @@
 				expect(searchWidget.searchFieldName).to.equal('query');
 			});
 
-			it('should fire a search-results-changed event when search completes', function(done) {
+			it('should fire a d2l-search-widget-results-changed event when search completes', function(done) {
 				server.respondWith(
 					'GET',
 					/.*/,
@@ -87,14 +87,14 @@
 				var listener = function(e) {
 					expect(e.detail).to.be.an('object');
 					expect(e.detail.properties.name).to.equal('a-thing');
-					document.removeEventListener('search-results-changed', listener, false);
+					document.removeEventListener('d2l-search-widget-results-changed', listener, false);
 					done();
 				};
-				document.addEventListener('search-results-changed', listener);
+				document.addEventListener('d2l-search-widget-results-changed', listener);
 				searchWidget.search();
 			});
 
-			it('should fire a search-results-changed event when the search is cleared', function(done) {
+			it('should fire a d2l-search-widget-results-changed event when the search is cleared', function(done) {
 				server.respondWith(
 					'GET',
 					/.*/,
@@ -105,10 +105,10 @@
 				var listener = function(e) {
 					expect(e.detail).to.be.an('object');
 					expect(e.detail.properties).to.be.undefined;
-					document.removeEventListener('search-results-changed', listener, false);
+					document.removeEventListener('d2l-search-widget-results-changed', listener, false);
 					done();
 				};
-				document.addEventListener('search-results-changed', listener);
+				document.addEventListener('d2l-search-widget-results-changed', listener);
 				searchWidget.clear();
 			});
 
@@ -123,10 +123,10 @@
 
 				searchWidget._searchString = 'something&something something';
 				var listener = function() {
-					document.removeEventListener('search-results-changed', listener, false);
+					document.removeEventListener('d2l-search-widget-results-changed', listener, false);
 					done();
 				};
-				document.addEventListener('search-results-changed', listener);
+				document.addEventListener('d2l-search-widget-results-changed', listener);
 				searchWidget.search();
 			});
 		});


### PR DESCRIPTION
The general convention being used elsewhere is `d2l-component-name-event-name`, which wasn't being done here.