### PR TITLE
US81632 - Typography audit

### DIFF
--- a/d2l-search-widget.html
+++ b/d2l-search-widget.html
@@ -1,10 +1,10 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-input/iron-input.html">
 <link rel="import" href="../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../d2l-siren-parser/d2l-siren-parser.html">
 <link rel="import" href="../d2l-typography/d2l-typography.html">
+<link rel="import" href="../iron-input/iron-input.html">
 <link rel="import" href="localize-behavior.html">
 
 <!--
@@ -22,9 +22,7 @@
 				margin: 0;
 			}
 			input {
-				@apply(--d2l-body-small-text);
-				color: var(--d2l-color-ferrite);
-				font-size: calc(var(--d2l-search-widget-height, 60px) / 3);
+				font-size: calc(var(--d2l-search-widget-height, 60px) / 3) !important;
 				width: 100%;
 				height: var(--d2l-search-widget-height, 60px);
 				border: 1px solid var(--d2l-color-titanius);
@@ -78,6 +76,7 @@
 		</d2l-ajax>
 
 		<input
+			class="d2l-typography"
 			is="iron-input"
 			bind-value="{{_searchInput}}"
 			placeholder="{{placeholderText}}"


### PR DESCRIPTION
Styles weren't actually being applied in the way we probably wanted them to here... in fact, the text was being rendered as Arial. Hah, whoops.

Note: the `!important` here is, I would say, bad-but-necessary. Class selector styles (i.e. `d2l-typography`) are applied with a higher priority than element selector styles (i.e. `input`), so we need to make sure we're overriding the `d2l-typography -> font-size` value here.

This PR is effectively a sub-PR of https://github.com/Brightspace/d2l-my-courses-ui/pull/300.