### PR TITLE
Re-add localize-behavior.html

### DIFF
--- a/d2l-search-widget-behavior.html
+++ b/d2l-search-widget-behavior.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../app-localize-behavior/app-localize-behavior.html">
 <link rel="import" href="../d2l-siren-parser/d2l-siren-parser.html">
 
 <script>
@@ -9,91 +8,8 @@
 	window.D2L = window.D2L || {};
 	window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
 
-	/** @polymerBehavior window.D2L.PolymerBehaviors.SearchWidgetLocalizeBehaviorImpl */
-	var LocalizeBehaviorImpl = {
-		properties: {
-			language: {
-				type: String,
-				computed: '_computeLanguage(resources)'
-			},
-			resources: {
-				value: function() {
-					var langs = {
-						'en': {
-							'search': 'Search',
-							'search.clear': 'Clear Search'
-						},
-						'ar': {
-							'search': 'بحث',
-							'search.clear': 'مسح البحث'
-						},
-						'es': {
-							'search': 'Buscar',
-							'search.clear': 'Borrar búsqueda'
-						},
-						'fr': {
-							'search': 'Rechercher',
-							'search.clear': 'Effacer la recherche'
-						},
-						'ja': {
-							'search': '検索',
-							'search.clear': '検索のクリア'
-						},
-						'ko': {
-							'search': '검색',
-							'search.clear': '검색 지우기'
-						},
-						'nl': {
-							'search': 'Zoeken',
-							'search.clear': 'Zoekopdracht wissen'
-						},
-						'pt': {
-							'search': 'Pesquisar',
-							'search.clear': 'Limpar Pesquisa'
-						},
-						'sv': {
-							'search': 'Sökning',
-							'search.clear': 'Rensa sökning'
-						},
-						'tr': {
-							'search': 'Ara',
-							'search.clear': 'Aramayı Temizle'
-						},
-						'zh': {
-							'search': '搜索',
-							'search.clear': '清除搜索'
-						},
-						'zh-tw': {
-							'search': '搜尋',
-							'search.clear': '清除搜尋'
-						}
-					};
-
-					return langs;
-				}
-			}
-		},
-		_computeLanguage: function(resources) {
-			var locale = document.documentElement.lang
-				|| document.documentElement.getAttribute('data-lang-default')
-				|| 'en-us';
-			locale = locale.toLowerCase();
-
-			if (resources[locale]) {
-				return locale;
-			}
-
-			var langAndRegion = locale.split('-');
-			if (resources[langAndRegion[0]]) {
-				return langAndRegion[0];
-			}
-
-			return 'en';
-		}
-	};
-
-	/** @polymerBehavior window.D2L.PolymerBehaviors.SearchWidgetBehaviorImpl */
-	var SearchWidgetBehaviorImpl = {
+	/** @polymerBehavior window.D2L.PolymerBehaviors.SearchWidgetBehavior */
+	window.D2L.PolymerBehaviors.SearchWidgetBehavior = {
 		properties: {
 			// If true, responses are cached locally (cleared on page refresh)
 			cacheResponses: {
@@ -117,6 +33,16 @@
 			},
 			// The Entity returned by the search Action
 			searchResults: Object,
+			// ARIA label used for search button. Should be localized by element consumer.
+			searchButtonLabel: {
+				type: String,
+				value: 'Search'
+			},
+			// ARIA label used for clear button. Should be localized by element consumer.
+			clearButtonLabel: {
+				type: String,
+				value: 'Clear Search'
+			},
 			_searchResultsCache: {
 				type: Object,
 				value: {}
@@ -148,11 +74,11 @@
 		},
 		_setClearIcon: function() {
 			this.$$('button > d2l-icon').setAttribute('icon', 'd2l-tier1:close-default');
-			this.$$('button').setAttribute('aria-label', this.localize('search.clear'));
+			this.$$('button').setAttribute('aria-label', this.clearButtonLabel);
 		},
 		_setSearchIcon: function() {
 			this.$$('button > d2l-icon').setAttribute('icon', 'd2l-tier1:search');
-			this.$$('button').setAttribute('aria-label', this.localize('search'));
+			this.$$('button').setAttribute('aria-label', this.searchButtonLabel);
 		},
 		_setSearchUrl: function() {
 			if (!this._searchAction) {
@@ -247,12 +173,5 @@
 			}
 		}
 	};
-
-	/** @polymerBehavior */
-	window.D2L.PolymerBehaviors.SearchWidgetBehavior = [
-		Polymer.AppLocalizeBehavior,
-		LocalizeBehaviorImpl,
-		SearchWidgetBehaviorImpl
-	];
 })();
 </script>

--- a/d2l-search-widget.html
+++ b/d2l-search-widget.html
@@ -2,6 +2,7 @@
 <link rel="import" href="../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../iron-input/iron-input.html">
+<link rel="import" href="localize-behavior.html">
 <link rel="import" href="d2l-search-widget-behavior.html">
 <link rel="import" href="d2l-search-widget-styles.html">
 
@@ -27,7 +28,7 @@
 		<button
 			type="button"
 			on-tap="_onButtonClick"
-			aria-label$="{{localize('search')}}">
+			aria-label$="[[searchButtonLabel]]">
 			<d2l-icon icon="d2l-tier1:search"></d2l-icon>
 		</button>
 	</template>
@@ -38,6 +39,7 @@
 			is: 'd2l-search-widget',
 
 			behaviors: [
+				window.D2L.SearchWidget.LocalizeBehavior,
 				window.D2L.PolymerBehaviors.SearchWidgetBehavior
 			]
 		});

--- a/demo/d2l-search-widget-demo.html
+++ b/demo/d2l-search-widget-demo.html
@@ -33,6 +33,8 @@
 			<d2l-search-widget
 				id="widget"
 				placeholder-text="Type and hit Enter or click icon to search!"
+				search-button-label="ARIA Search label"
+				clear-button-label="ARIA Clear label"
 				search-action='{"name":"search-course-collection","method":"GET","href":"/components/d2l-search-widget/demo/response.json","fields":[{"name":"search","type":"search","value":""}]}'
 				search-field-name="search"></d2l-search-widget>
 			<p>

--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -1,0 +1,95 @@
+<link rel="import" href="../app-localize-behavior/app-localize-behavior.html">
+
+<script>
+'use strict';
+
+(function() {
+	window.D2L = window.D2L || {};
+	window.D2L.SearchWidget = window.D2L.SearchWidget || {};
+
+	/** @polymerBehavior D2L.PolymerBehaviors.SearchWidget.LocalizeBehavior */
+	window.D2L.SearchWidget.LocalizeBehaviorImpl = {
+		properties: {
+			language: {
+				type: String,
+				computed: '_computeLanguage(resources)'
+			},
+			resources: {
+				value: function() {
+					var langs = {
+						'en': {
+							'search': 'Search',
+							'search.clear': 'Clear Search'
+						},
+						'ar': {
+							'search': 'بحث',
+							'search.clear': 'مسح البحث'
+						},
+						'es': {
+							'search': 'Buscar',
+							'search.clear': 'Borrar búsqueda'
+						},
+						'fr': {
+							'search': 'Rechercher',
+							'search.clear': 'Effacer la recherche'
+						},
+						'ja': {
+							'search': '検索',
+							'search.clear': '検索のクリア'
+						},
+						'ko': {
+							'search': '검색',
+							'search.clear': '검색 지우기'
+						},
+						'nl': {
+							'search': 'Zoeken',
+							'search.clear': 'Zoekopdracht wissen'
+						},
+						'pt': {
+							'search': 'Pesquisar',
+							'search.clear': 'Limpar Pesquisa'
+						},
+						'sv': {
+							'search': 'Sökning',
+							'search.clear': 'Rensa sökning'
+						},
+						'tr': {
+							'search': 'Ara',
+							'search.clear': 'Aramayı Temizle'
+						},
+						'zh': {
+							'search': '搜索',
+							'search.clear': '清除搜索'
+						},
+						'zh-tw': {
+							'search': '搜尋',
+							'search.clear': '清除搜尋'
+						}
+					};
+					return langs;
+				}
+			}
+		},
+		_computeLanguage: function(resources) {
+			var locale = document.documentElement.lang
+				|| document.documentElement.getAttribute('data-lang-default')
+				|| 'en-us';
+			locale = locale.toLowerCase();
+			if (resources[locale]) {
+				return locale;
+			}
+			var langAndRegion = locale.split('-');
+			if (resources[langAndRegion[0]]) {
+				return langAndRegion[0];
+			}
+			return 'en';
+		}
+	};
+
+	/** @polymerBehavior */
+	window.D2L.SearchWidget.LocalizeBehavior = [
+		Polymer.AppLocalizeBehavior,
+		window.D2L.SearchWidget.LocalizeBehaviorImpl
+	];
+})();
+</script>


### PR DESCRIPTION
Rationale behind this is that the My Courses custom search widget wants to implement d2l-search-widget-behavior, but it will have conflicting localize-behaviours. Instead, just pass in the two localized phrases (ARIA labels for the search/clear buttons), much in the same way we pass in the placeholder text.

We've taken a similar approach with [d2l-simple-overlay](https://github.com/Brightspace/simple-overlay/blob/master/d2l-simple-overlay.html#L46).