### PR TITLE
Some minor fixes

### DIFF
--- a/d2l-search-widget-behavior.html
+++ b/d2l-search-widget-behavior.html
@@ -70,9 +70,9 @@
 		},
 		// Clears search text and triggers search
 		clear: function() {
+			// Triggers _onSearchInputChanged to call _setSearchUrl with empty query
 			this.set('_searchInput', '');
 			this.set('_showClearIcon', false);
-			this._setSearchUrl();
 		},
 		_parser: null,
 		_setSearchUrl: function() {
@@ -136,7 +136,9 @@
 			this.set('_searchAction', this._parser.parse(entity).actions[0]);
 		},
 		_onSearchInputChanged: function(newSearchString) {
-			if (newSearchString.length !== 0) {
+			if (newSearchString.length === 0) {
+				this._setSearchUrl();
+			} else {
 				this.set('_showClearIcon', false);
 			}
 		},

--- a/d2l-search-widget-behavior.html
+++ b/d2l-search-widget-behavior.html
@@ -54,32 +54,27 @@
 			_searchInput: {
 				type: String,
 				observer: '_onSearchInputChanged'
+			},
+			_showClearIcon: {
+				type: Boolean,
+				observer: '_onShowClearIconChanged'
 			}
 		},
 		// Trigger the search manually, e.g. via an external "Search" button
 		search: function() {
-			this._isSearched = true;
+			if (this._searchInput.trim() === '') {
+				return;
+			}
+			this.set('_showClearIcon', true);
 			this._setSearchUrl();
 		},
 		// Clears search text and triggers search
 		clear: function() {
-			this._isSearched = false;
 			this.set('_searchInput', '');
+			this.set('_showClearIcon', false);
 			this._setSearchUrl();
 		},
-		_isSearched: false,
 		_parser: null,
-		_updateIcon: function() {
-			this._isSearched ? this._setClearIcon() : this._setSearchIcon();
-		},
-		_setClearIcon: function() {
-			this.$$('button > d2l-icon').setAttribute('icon', 'd2l-tier1:close-default');
-			this.$$('button').setAttribute('aria-label', this.clearButtonLabel);
-		},
-		_setSearchIcon: function() {
-			this.$$('button > d2l-icon').setAttribute('icon', 'd2l-tier1:search');
-			this.$$('button').setAttribute('aria-label', this.searchButtonLabel);
-		},
 		_setSearchUrl: function() {
 			if (!this._searchAction) {
 				return;
@@ -111,12 +106,22 @@
 			return queryString ? action.href + '?' + queryString : action.href;
 		},
 		_onButtonClick: function() {
-			if (this._isSearched) {
+			if (this._showClearIcon) {
 				this.clear();
 			} else {
 				this.search();
 			}
-			this._updateIcon();
+		},
+		_onShowClearIconChanged: function(showClearIcon) {
+			if (showClearIcon) {
+				// Set clear icon
+				this.$$('button > d2l-icon').setAttribute('icon', 'd2l-tier1:close-default');
+				this.$$('button').setAttribute('aria-label', this.clearButtonLabel);
+			} else {
+				// Set search icon
+				this.$$('button > d2l-icon').setAttribute('icon', 'd2l-tier1:search');
+				this.$$('button').setAttribute('aria-label', this.searchButtonLabel);
+			}
 		},
 		_onSearchActionChanged: function(searchAction) {
 			if ('string' === typeof searchAction) {
@@ -131,19 +136,14 @@
 			this.set('_searchAction', this._parser.parse(entity).actions[0]);
 		},
 		_onSearchInputChanged: function(newSearchString) {
-			if (newSearchString.length === 0) {
-				return;
+			if (newSearchString.length !== 0) {
+				this.set('_showClearIcon', false);
 			}
-			this._isSearched = false;
-			// Need to directly set search icon, as _isSearched may already be true here
-			// e.g. user types, searches, then adds a character to search string
-			this._setSearchIcon();
 		},
 		_onSearchInputKeyPressed: function(e) {
 			if (e.keyCode === 13) {
 				// If Enter key pressed, do the search
 				this.search();
-				this._updateIcon();
 			}
 		},
 		_onSearchResponse: function(e) {

--- a/d2l-search-widget-styles.html
+++ b/d2l-search-widget-styles.html
@@ -1,6 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
-<link rel="import" href="../d2l-typography/d2l-typography.html">
 
 <dom-module id="d2l-search-widget-styles">
 	<template>

--- a/d2l-search-widget.html
+++ b/d2l-search-widget.html
@@ -21,8 +21,7 @@
 			is="iron-input"
 			bind-value="{{_searchInput}}"
 			placeholder="{{placeholderText}}"
-			on-keydown="_onSearchInputKeyPressed"
-			on-input="_setSearchIcon">
+			on-keydown="_onSearchInputKeyPressed">
 		</input>
 
 		<button

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "npm run test:lint:js && npm run test:lint:wc && wct",
     "test:lint:js": "eslint test/ --ext .js,.html && eslint *.html",
     "test:lint:wc": "polymer lint -i *.html",
+    "test:no-lint": "wct -p",
     "test:unit:local": "polymer test"
   },
   "author": "D2L Corporation",
@@ -19,6 +20,7 @@
     "eslint-config-brightspace": "^0.2.4",
     "eslint-plugin-html": "^1.5.3",
     "polymer-cli": "^0.16.0",
-    "rimraf": "^2.5.4"
+    "rimraf": "^2.5.4",
+    "web-component-tester": "^5.0.0"
   }
 }

--- a/test/d2l-search-widget.html
+++ b/test/d2l-search-widget.html
@@ -102,6 +102,7 @@
 					done();
 				};
 				document.addEventListener('d2l-search-widget-results-changed', listener);
+				searchWidget._searchInput = 'foo';
 				searchWidget.search();
 			});
 
@@ -120,6 +121,7 @@
 					done();
 				};
 				document.addEventListener('d2l-search-widget-results-changed', listener);
+				searchWidget._searchInput = 'foo';
 				searchWidget.clear();
 			});
 
@@ -142,6 +144,10 @@
 			});
 
 			describe('button icon', function() {
+				beforeEach(function() {
+					searchWidget._searchInput = 'foo';
+				});
+
 				it('should default to a search icon and correct ARIA label', function() {
 					expect(searchWidget.$$('button > d2l-icon').getAttribute('icon')).to.contain('search');
 					expect(searchWidget.$$('button').getAttribute('aria-label')).to.equal('Search');
@@ -151,7 +157,7 @@
 					server.respondWith('GET', /.*/, [200, {}, JSON.stringify({})]);
 
 					var listener = function() {
-						expect(searchWidget._isSearched).to.be.true;
+						expect(searchWidget._showClearIcon).to.be.true;
 						expect(searchWidget.$$('button > d2l-icon').getAttribute('icon')).to.contain('close-default');
 						expect(searchWidget.$$('button').getAttribute('aria-label')).to.equal('Clear Search');
 						document.removeEventListener('d2l-search-widget-results-changed', listener, false);
@@ -164,12 +170,11 @@
 				it('should change to a search icon when cleared', function(done) {
 					server.respondWith('GET', /.*/, [200, {}, JSON.stringify({})]);
 
-					searchWidget._isSearched = true;
-					searchWidget._updateIcon();
+					searchWidget.set('_showClearIcon', true);
 					expect(searchWidget.$$('button > d2l-icon').getAttribute('icon')).to.contain('close-default');
 
 					var listener = function() {
-						expect(searchWidget._isSearched).to.be.false;
+						expect(searchWidget._showClearIcon).to.be.false;
 						expect(searchWidget.$$('d2l-icon').getAttribute('icon')).to.contain('search');
 						expect(searchWidget.$$('button').getAttribute('aria-label')).to.equal('Search');
 						document.removeEventListener('d2l-search-widget-results-changed', listener, false);
@@ -183,12 +188,12 @@
 					server.respondWith('GET', /.*/, [200, {}, JSON.stringify({})]);
 
 					var listener = function() {
-						expect(searchWidget._isSearched).to.be.true;
+						expect(searchWidget._showClearIcon).to.be.true;
 						expect(searchWidget.$$('button > d2l-icon').getAttribute('icon')).to.contain('close-default');
 						expect(searchWidget.$$('button').getAttribute('aria-label')).to.equal('Clear Search');
 
-						searchWidget._searchInput = 'foo';
-						expect(searchWidget._isSearched).to.be.false;
+						searchWidget._searchInput = 'foobar';
+						expect(searchWidget._showClearIcon).to.be.false;
 						expect(searchWidget.$$('button > d2l-icon').getAttribute('icon')).to.contain('search');
 						expect(searchWidget.$$('button').getAttribute('aria-label')).to.equal('Search');
 						document.removeEventListener('d2l-search-widget-results-changed', listener, false);
@@ -216,6 +221,7 @@
 						done();
 					};
 					document.addEventListener('d2l-search-widget-results-changed', listener);
+					searchWidget._searchInput = 'foo';
 					searchWidget.search();
 				});
 
@@ -235,6 +241,7 @@
 						done();
 					};
 					document.addEventListener('d2l-search-widget-results-changed', listener);
+					searchWidgetCached._searchInput = 'foo';
 					searchWidgetCached.search();
 				});
 
@@ -262,7 +269,7 @@
 						document.removeEventListener('d2l-search-widget-results-changed', secondListener, false);
 						document.addEventListener('d2l-search-widget-results-changed', thirdListener);
 						spy = sinon.spy(searchWidgetCached.$$('d2l-ajax'), 'generateRequest');
-						searchWidgetCached._searchInput = 'foo';
+						searchWidgetCached._searchInput = 'bar';
 						searchWidgetCached.search();
 					};
 					var thirdListener = function() {
@@ -272,7 +279,7 @@
 						done();
 					};
 					document.addEventListener('d2l-search-widget-results-changed', firstListener);
-					searchWidgetCached._searchInput = 'foo';
+					searchWidgetCached._searchInput = 'bar';
 					searchWidgetCached.search();
 				});
 			});

--- a/test/d2l-search-widget.html
+++ b/test/d2l-search-widget.html
@@ -95,6 +95,7 @@
 						req.respond(200, {}, JSON.stringify(entity));
 					});
 
+				searchWidget._searchInput = 'foo';
 				var listener = function(e) {
 					expect(e.detail).to.be.an('object');
 					expect(e.detail.properties.name).to.equal('a-thing');
@@ -102,7 +103,6 @@
 					done();
 				};
 				document.addEventListener('d2l-search-widget-results-changed', listener);
-				searchWidget._searchInput = 'foo';
 				searchWidget.search();
 			});
 
@@ -114,6 +114,8 @@
 						req.respond(200, {}, JSON.stringify({}));
 					});
 
+				searchWidget._searchInput = 'foo';
+				searchWidget.search();
 				var listener = function(e) {
 					expect(e.detail).to.be.an('object');
 					expect(e.detail.properties).to.be.undefined;
@@ -121,7 +123,6 @@
 					done();
 				};
 				document.addEventListener('d2l-search-widget-results-changed', listener);
-				searchWidget._searchInput = 'foo';
 				searchWidget.clear();
 			});
 
@@ -170,7 +171,7 @@
 				it('should change to a search icon when cleared', function(done) {
 					server.respondWith('GET', /.*/, [200, {}, JSON.stringify({})]);
 
-					searchWidget.set('_showClearIcon', true);
+					searchWidget.search();
 					expect(searchWidget.$$('button > d2l-icon').getAttribute('icon')).to.contain('close-default');
 
 					var listener = function() {


### PR DESCRIPTION
Ostensibly for US82482.

- Remove `_isSearched` in favour of `_showClearIcon` - this is a reactionary variable really, not a state per se.
- Don't search whitespace, no point (`.trim()`)
- Immediately return results if user clears search field entirely