### PR TITLE
Move where we .trim()

### DIFF
--- a/d2l-search-widget-behavior.html
+++ b/d2l-search-widget-behavior.html
@@ -62,9 +62,6 @@
 		},
 		// Trigger the search manually, e.g. via an external "Search" button
 		search: function() {
-			if (this._searchInput.trim() === '') {
-				return;
-			}
 			this.set('_showClearIcon', true);
 			this._setSearchUrl();
 		},
@@ -81,7 +78,7 @@
 			}
 
 			var query = {};
-			query[this.searchFieldName] = encodeURIComponent(this._searchInput);
+			query[this.searchFieldName] = encodeURIComponent(this._searchInput.trim());
 
 			this.set('_searchUrl', this._createActionUrl(this._searchAction, query));
 		},


### PR DESCRIPTION
Can't do it in search, as this will mean the initial call to search (when the `_searchUrl` goes from `undefined` to something with _?search=""_ kinda thing) will not happen.