### PR TITLE
DE24337 - Add clearCache to manually clear cache

### DIFF
--- a/d2l-search-widget-behavior.html
+++ b/d2l-search-widget-behavior.html
@@ -43,10 +43,6 @@
 				type: String,
 				value: 'Clear Search'
 			},
-			_searchResultsCache: {
-				type: Object,
-				value: {}
-			},
 			_searchUrl: {
 				type: String,
 				observer: '_onSearchUrlChanged'
@@ -69,7 +65,16 @@
 			// Triggers _onSearchInputChanged to call _setSearchUrl with empty query
 			this.set('_searchInput', '');
 		},
+		// Manually clears cache
+		clearCache: function(key) {
+			if (key) {
+				delete this._searchResultsCache[key];
+			} else {
+				this._searchResultsCache = {};
+			}
+		},
 		_parser: null,
+		_searchResultsCache: {},
 		_setSearchUrl: function() {
 			if (!this._searchAction) {
 				return;

--- a/test/d2l-search-widget.html
+++ b/test/d2l-search-widget.html
@@ -283,6 +283,20 @@
 					searchWidgetCached._searchInput = 'bar';
 					searchWidgetCached.search();
 				});
+
+				it('should clear entire cache if no key specified', function() {
+					searchWidgetCached._searchResultsCache['foo'] = entity;
+					searchWidgetCached.clearCache();
+					expect(searchWidgetCached._searchResultsCache['foo']).to.be.undefined;
+				});
+
+				it('should clear specific cache entry if key specified', function() {
+					searchWidgetCached._searchResultsCache['foo'] = entity;
+					searchWidgetCached._searchResultsCache['bar'] = entity;
+					searchWidgetCached.clearCache('bar');
+					expect(searchWidgetCached._searchResultsCache['foo']).to.not.be.undefined;
+					expect(searchWidgetCached._searchResultsCache['bar']).to.be.undefined;
+				});
 			});
 		});
 		</script>


### PR DESCRIPTION
Rather than being gross and setting _searchResultsCache = {} from the behaviour consumer, make it available as a nice API, whoop whoop.

This is part one of the DE fix; part two is https://github.com/Brightspace/d2l-my-courses-ui/pull/342