### PR TITLE
US90475 Use d2lfetch in favour of d2l-ajax

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ This will start a local server using `polymer-cli` which you can use to explore 
 
 The `d2l-search-widget` takes a Siren Hypermedia action as a `search-action` attribute, and will perform this action whenever the search is triggered. The `search-field-name` attribute should be set to the name of the Siren Field that the search field text should correspond to. `placeholder-text` will set the placeholder text on the input element.
 
-Optionally, setting the `cache-responses` attribute will cache the responses from each search within the widget. This cache is short-lived (i.e. it is lost on a page refresh), but it helps in particular with the "cleared search" results, so that clearing the search will immediately return the results (after they've been fetched once).
+`d2l-search-widget` uses [`d2l-fetch`][d2lfetch] to actually fetch data. When using the `d2l-search-widget`, we strongly recommend also using the [`d2l-simple-cache`][d2lfetchsimplecache] and [`d2l-auth`][d2lfetchauth] middlewares for this as well, and `use` them in your app.
 
-A `d2l-search-widget-results-changed` event is fired when the search completes. The event fires immediately if the response is cached. The event's `value` will contain the response, parsed with `node-siren-parser`.
+A `d2l-search-widget-results-changed` event is fired when the search completes. The event's `value` will contain the response, parsed with `node-siren-parser`.
 
 The widget will have a default height of 60px; this can be overridden with `--d2l-search-widget-height`.
 
@@ -71,5 +71,8 @@ d2l-search-widget {
 
 5. Submit a pull request to this repository. Wait for tests to run and someone to chime in.
 
-[polymer]: https://www.polymer-project.org/1.0/
+[polymer]: https://www.polymer-project.org/
 [siren]: https://github.com/kevinswiber/siren
+[d2lfetch]: https://github.com/Brightspace/d2l-fetch
+[d2lfetchsimplecache]: https://github.com/Brightspace/d2l-fetch-simple-cache
+[d2lfetchauth]: https://github.com/Brightspace/d2l-fetch-auth

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,6 @@
   ],
   "dependencies": {
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2",
-    "d2l-ajax": "^3.4.1",
     "d2l-colors": "^2.3.0",
     "d2l-icons": "^3.2.0",
     "iron-input": "^1.0.10",

--- a/d2l-search-widget-behavior.html
+++ b/d2l-search-widget-behavior.html
@@ -1,12 +1,11 @@
 <link rel="import" href="../polymer/polymer.html">
 <script src="https://s.brightspace.com/lib/siren-parser/6.1.0/siren-parser-global.js"></script>
 <script src="https://s.brightspace.com/lib/d2lfetch/1.2.0/d2lfetch.js"></script>
-<script src="https://s.brightspace.com/lib/d2lfetch-auth/0.6.0/d2lfetch-auth.js"></script>
-<script src="https://s.brightspace.com/lib/d2lfetch-dedupe/0.10.0/d2lfetch-dedupe.js"></script>
-<script src="https://s.brightspace.com/lib/d2lfetch-simple-cache/0.3.0/d2lfetch-simple-cache.js"></script>
 
 <script>
 'use strict';
+
+/* global Promise */
 
 (function() {
 	window.D2L = window.D2L || {};
@@ -15,11 +14,6 @@
 	/** @polymerBehavior window.D2L.PolymerBehaviors.SearchWidgetBehavior */
 	window.D2L.PolymerBehaviors.SearchWidgetBehavior = {
 		properties: {
-			// If true, responses are cached locally (cleared on page refresh)
-			cacheResponses: {
-				type: Boolean,
-				value: false
-			},
 			// Placeholder text that appears in the search field
 			placeholderText: {
 				type: String,
@@ -60,11 +54,6 @@
 				observer: '_onShowClearIconChanged'
 			}
 		},
-		ready: function() {
-			window.d2lfetch.use({name: 'auth', fn: window.d2lfetch.auth});
-			window.d2lfetch.use({name: 'dedupe', fn: window.d2lfetch.dedupe});
-			window.d2lfetch.use({name: 'simpleCache', fn: window.d2lfetch.simpleCache});
-		},
 		// Trigger the search manually, e.g. via an external "Search" button
 		search: function() {
 			this._setSearchUrl();
@@ -74,15 +63,6 @@
 			// Triggers _onSearchInputChanged to call _setSearchUrl with empty query
 			this.set('_searchInput', '');
 		},
-		// Manually clears cache
-		clearCache: function(key) {
-			if (key) {
-				delete this._searchResultsCache[key];
-			} else {
-				this._searchResultsCache = {};
-			}
-		},
-		_searchResultsCache: {},
 		_setSearchUrl: function() {
 			if (!this._searchAction) {
 				return;
@@ -157,11 +137,6 @@
 		},
 		_onSearchResponse: function(searchResponse) {
 			this.set('searchResults', searchResponse || {});
-
-			if (this.cacheResponses) {
-				this._searchResultsCache[e.detail.url] = this.searchResults;
-			}
-
 			this.fire('d2l-search-widget-results-changed', this.searchResults);
 		},
 		_onSearchUrlChanged: function(url) {
@@ -169,28 +144,18 @@
 
 			// Using an observer means if search button is clicked multiple times with
 			// the same query, only the first time generates a call
-			if (url) {
-				if (this.cacheResponses && this._searchResultsCache[url]) {
-					// Don't redo the call if we've done it before
-					this.set('searchResults', this._searchResultsCache[url]);
-					this.fire('d2l-search-widget-results-changed', this.searchResults);
-				} else {
-					window.d2lfetch
-						.fetch(new Request(url, {
-							headers: {
-								'accept': 'application/vnd.siren+json'
-							}
-						}))
-						.then(function(response) {
-							if (response.ok) {
-								return response.json();
-							}
-							return Promise.reject(response.status + ' ' + response.statusText);
-						})
-						.then(window.D2L.Hypermedia.Siren.Parse)
-						.then(this._onSearchResponse.bind(this));
-				}
-			}
+			return window.d2lfetch
+				.fetch(new Request(url, {
+					headers: { Accept: 'application/vnd.siren+json' }
+				}))
+				.then(function(response) {
+					if (response.ok) {
+						return response.json();
+					}
+					return Promise.reject(response.status + ' ' + response.statusText);
+				})
+				.then(window.D2L.Hypermedia.Siren.Parse)
+				.then(this._onSearchResponse.bind(this));
 		}
 	};
 })();

--- a/d2l-search-widget-behavior.html
+++ b/d2l-search-widget-behavior.html
@@ -1,5 +1,9 @@
 <link rel="import" href="../polymer/polymer.html">
 <script src="https://s.brightspace.com/lib/siren-parser/6.1.0/siren-parser-global.js"></script>
+<script src="https://s.brightspace.com/lib/d2lfetch/1.2.0/d2lfetch.js"></script>
+<script src="https://s.brightspace.com/lib/d2lfetch-auth/0.6.0/d2lfetch-auth.js"></script>
+<script src="https://s.brightspace.com/lib/d2lfetch-dedupe/0.10.0/d2lfetch-dedupe.js"></script>
+<script src="https://s.brightspace.com/lib/d2lfetch-simple-cache/0.3.0/d2lfetch-simple-cache.js"></script>
 
 <script>
 'use strict';
@@ -55,6 +59,11 @@
 				type: Boolean,
 				observer: '_onShowClearIconChanged'
 			}
+		},
+		ready: function() {
+			window.d2lfetch.use({name: 'auth', fn: window.d2lfetch.auth});
+			window.d2lfetch.use({name: 'dedupe', fn: window.d2lfetch.dedupe});
+			window.d2lfetch.use({name: 'simpleCache', fn: window.d2lfetch.simpleCache});
 		},
 		// Trigger the search manually, e.g. via an external "Search" button
 		search: function() {
@@ -146,17 +155,14 @@
 				this.search();
 			}
 		},
-		_onSearchResponse: function(e) {
-			if (e.detail.status === 200 || e.detail.status === 304) {
-				var searchResponse = window.D2L.Hypermedia.Siren.Parse(e.detail.xhr.response);
-				this.set('searchResults', searchResponse || {});
+		_onSearchResponse: function(searchResponse) {
+			this.set('searchResults', searchResponse || {});
 
-				if (this.cacheResponses) {
-					this._searchResultsCache[e.detail.url] = this.searchResults;
-				}
-
-				this.fire('d2l-search-widget-results-changed', this.searchResults);
+			if (this.cacheResponses) {
+				this._searchResultsCache[e.detail.url] = this.searchResults;
 			}
+
+			this.fire('d2l-search-widget-results-changed', this.searchResults);
 		},
 		_onSearchUrlChanged: function(url) {
 			this.set('_showClearIcon', this._searchInput.trim() !== '');
@@ -169,7 +175,20 @@
 					this.set('searchResults', this._searchResultsCache[url]);
 					this.fire('d2l-search-widget-results-changed', this.searchResults);
 				} else {
-					this.$$('d2l-ajax').generateRequest();
+					window.d2lfetch
+						.fetch(new Request(url, {
+							headers: {
+								'accept': 'application/vnd.siren+json'
+							}
+						}))
+						.then(function(response) {
+							if (response.ok) {
+								return response.json();
+							}
+							return Promise.reject(response.status + ' ' + response.statusText);
+						})
+						.then(window.D2L.Hypermedia.Siren.Parse)
+						.then(this._onSearchResponse.bind(this));
 				}
 			}
 		}

--- a/d2l-search-widget.html
+++ b/d2l-search-widget.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../iron-input/iron-input.html">
 <link rel="import" href="localize-behavior.html">
@@ -9,12 +8,6 @@
 <dom-module id="d2l-search-widget">
 	<template>
 		<style include="d2l-search-widget-styles"></style>
-
-		<d2l-ajax
-			url="[[_searchUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onSearchResponse">
-		</d2l-ajax>
 
 		<input
 			is="iron-input"

--- a/test/d2l-search-widget.html
+++ b/test/d2l-search-widget.html
@@ -23,24 +23,14 @@
 			</template>
 		</test-fixture>
 
-		<test-fixture id="search-widget-cached">
-			<template>
-				<d2l-search-widget
-					search-action='{"name": "do-a-thing", "method": "GET", "href": "/some/url", "fields": [{"name": "query", "type": "search", "value": ""}]}'
-					search-field-name="query"
-					cache-responses="true"></d2l-search-widget>
-			</template>
-		</test-fixture>
-
 		<script>
-		/* global describe, it, beforeEach, afterEach, fixture, expect, sinon */
+		/* global Promise, describe, it, beforeEach, afterEach, fixture, expect, sinon */
 		'use strict';
 
 		describe('d2l-search-widget', function() {
 			var searchWidget,
 				searchWidgetBasic,
-				searchWidgetCached,
-				server,
+				sandbox,
 				entity = {
 					class: ['foo'],
 					properties: {
@@ -61,13 +51,18 @@
 			beforeEach(function() {
 				searchWidget = fixture('search-widget');
 				searchWidgetBasic = fixture('search-widget-basic');
-				searchWidgetCached = fixture('search-widget-cached');
-				server = sinon.fakeServer.create();
-				server.respondImmediately = true;
+				sandbox = sinon.sandbox.create();
+
+				window.d2lfetch.fetch = sandbox.stub().returns(Promise.resolve({
+					ok: true,
+					json: function() {
+						return entity;
+					}
+				}));
 			});
 
 			afterEach(function() {
-				server.restore();
+				sandbox.restore();
 			});
 
 			it('has sensible defaults', function() {
@@ -88,13 +83,6 @@
 			});
 
 			it('should fire a d2l-search-widget-results-changed event when search completes', function(done) {
-				server.respondWith(
-					'GET',
-					/.*/,
-					function(req) {
-						req.respond(200, {}, JSON.stringify(entity));
-					});
-
 				searchWidget._searchInput = 'foo';
 				var listener = function(e) {
 					expect(e.detail).to.be.an('object');
@@ -107,18 +95,9 @@
 			});
 
 			it('should fire a d2l-search-widget-results-changed event when the search is cleared', function(done) {
-				server.respondWith(
-					'GET',
-					/.*/,
-					function(req) {
-						req.respond(200, {}, JSON.stringify({}));
-					});
-
 				searchWidget._searchInput = 'foo';
 				searchWidget.search();
-				var listener = function(e) {
-					expect(e.detail).to.be.an('object');
-					expect(e.detail.properties).to.be.undefined;
+				var listener = function() {
 					document.removeEventListener('d2l-search-widget-results-changed', listener, false);
 					done();
 				};
@@ -127,16 +106,11 @@
 			});
 
 			it('should URI-encode query strings', function(done) {
-				server.respondWith(
-					'GET',
-					/.*/,
-					function(req) {
-						expect(req.url).to.match(/something%26something%20something/);
-						req.respond(200, {}, JSON.stringify({}));
-					});
+				var spy = sandbox.spy(searchWidget, '_onSearchUrlChanged');
 
 				searchWidget._searchInput = 'something&something something';
 				var listener = function() {
+					expect(spy).to.have.been.calledWith(sinon.match('something%26something%20something'));
 					document.removeEventListener('d2l-search-widget-results-changed', listener, false);
 					done();
 				};
@@ -155,8 +129,6 @@
 				});
 
 				it('should change to an X icon when a search is done', function(done) {
-					server.respondWith('GET', /.*/, [200, {}, JSON.stringify({})]);
-
 					var listener = function() {
 						expect(searchWidget._showClearIcon).to.be.true;
 						expect(searchWidget.$$('button > d2l-icon').getAttribute('icon')).to.contain('close-default');
@@ -169,8 +141,6 @@
 				});
 
 				it('should change to a search icon when cleared', function(done) {
-					server.respondWith('GET', /.*/, [200, {}, JSON.stringify({})]);
-
 					searchWidget.search();
 					expect(searchWidget.$$('button > d2l-icon').getAttribute('icon')).to.contain('close-default');
 
@@ -186,8 +156,6 @@
 				});
 
 				it('should switch back to search icon when search string is updated', function(done) {
-					server.respondWith('GET', /.*/, [200, {}, JSON.stringify({})]);
-
 					var listener = function() {
 						expect(searchWidget._showClearIcon).to.be.true;
 						expect(searchWidget.$$('button > d2l-icon').getAttribute('icon')).to.contain('close-default');
@@ -202,100 +170,6 @@
 					};
 					document.addEventListener('d2l-search-widget-results-changed', listener);
 					searchWidget.$$('button').click();
-				});
-			});
-
-			describe('cacheResponses', function() {
-				it('should not cache responses by default', function(done) {
-					var url;
-					server.respondWith(
-						'GET',
-						/.*/,
-						function(req) {
-							url = req.url;
-							req.respond(200, {}, JSON.stringify(entity));
-						});
-
-					var listener = function() {
-						expect(searchWidget._searchResultsCache[url]).to.be.undefined;
-						document.removeEventListener('d2l-search-widget-results-changed', listener, false);
-						done();
-					};
-					document.addEventListener('d2l-search-widget-results-changed', listener);
-					searchWidget._searchInput = 'foo';
-					searchWidget.search();
-				});
-
-				it('should cache the response for a given URL', function(done) {
-					var url;
-					server.respondWith(
-						'GET',
-						/.*/,
-						function(req) {
-							url = req.url;
-							req.respond(200, {}, JSON.stringify(entity));
-						});
-
-					var listener = function() {
-						expect(searchWidgetCached._searchResultsCache[url]).to.not.be.undefined;
-						document.removeEventListener('d2l-search-widget-results-changed', listener, false);
-						done();
-					};
-					document.addEventListener('d2l-search-widget-results-changed', listener);
-					searchWidgetCached._searchInput = 'foo';
-					searchWidgetCached.search();
-				});
-
-				it('should not re-request if a URLs response is already cached', function(done) {
-					var url;
-					server.respondWith(
-						'GET',
-						/.*/,
-						function(req) {
-							url = req.url;
-							req.respond(200, {}, JSON.stringify(entity));
-						});
-
-					var spy;
-
-					var firstListener = function() {
-						// Initial search response - should hit fakeServer
-						document.removeEventListener('d2l-search-widget-results-changed', firstListener, false);
-						document.addEventListener('d2l-search-widget-results-changed', secondListener);
-						expect(searchWidgetCached._searchResultsCache[url]).to.not.be.undefined;
-						searchWidgetCached.clear();
-					};
-					var secondListener = function() {
-						// Clearing search response - should hit fakeServer
-						document.removeEventListener('d2l-search-widget-results-changed', secondListener, false);
-						document.addEventListener('d2l-search-widget-results-changed', thirdListener);
-						spy = sinon.spy(searchWidgetCached.$$('d2l-ajax'), 'generateRequest');
-						searchWidgetCached._searchInput = 'bar';
-						searchWidgetCached.search();
-					};
-					var thirdListener = function() {
-						// Second 'foo' search response - should hit cached responses
-						document.removeEventListener('d2l-search-widget-results-changed', thirdListener, false);
-						expect(spy.called).to.be.false;
-						done();
-					};
-					document.addEventListener('d2l-search-widget-results-changed', firstListener);
-					searchWidgetCached._searchInput = 'bar';
-					searchWidgetCached.search();
-				});
-
-				it('should clear entire cache if no key specified', function() {
-					searchWidgetCached._searchResultsCache['foo'] = entity;
-					searchWidgetCached.clearCache();
-					expect(searchWidgetCached._searchResultsCache['foo']).to.be.undefined;
-				});
-
-				it('should clear specific cache entry if key specified', function() {
-					searchWidgetCached._searchResultsCache['foo'] = entity;
-					searchWidgetCached._searchResultsCache['bar'] = entity;
-					searchWidgetCached.clearCache('bar');
-					expect(searchWidgetCached._searchResultsCache['foo']).to.not.be.undefined;
-					expect(searchWidgetCached._searchResultsCache['bar']).to.be.undefined;
 				});
 			});
 		});


### PR DESCRIPTION
It was discovered in testing d2l-my-courses that d2lfetch presents a fairly significant performance improvement over d2l-ajax, so moving to use that instead. It's unlikely that we'll see as much of a benefit here, but it is a bit nicer to use in terms of API, and will make things generally cleaner for little effort.

I also removed the built-in caching here. Rather than implementing this here, we should just recommend that the consumer of the element also use the d2l-fetch-simple-cache middleware, along with d2l-fetch-auth. This allows the component to be much simpler, and prevents us from having a double-caching situation in the (likely) case where the user _is_ using d2l-fetch-simple-cache.

This is a breaking change, however, so this will be released with a major version bump.