### PR TITLE
Use bower-based d2l-fetch

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,8 @@
     "d2l-colors": "^2.3.0",
     "d2l-icons": "^3.2.0",
     "iron-input": "^1.0.10",
-    "polymer": "^1.7.0"
+    "polymer": "^1.7.0",
+    "d2l-fetch": "Brightspace/d2l-fetch#^1.5.1"
   },
   "devDependencies": {
     "d2l-demo-template": "^1.0.2",

--- a/d2l-search-widget-behavior.html
+++ b/d2l-search-widget-behavior.html
@@ -1,6 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
 <script src="https://s.brightspace.com/lib/siren-parser/6.1.0/siren-parser-global.js"></script>
-<script src="https://s.brightspace.com/lib/d2lfetch/1.2.0/d2lfetch.js"></script>
 
 <script>
 'use strict';

--- a/d2l-search-widget.html
+++ b/d2l-search-widget.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-fetch/d2l-fetch.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../iron-input/iron-input.html">
 <link rel="import" href="localize-behavior.html">


### PR DESCRIPTION
This allows us to take advantage of bower's dependency/version resolution to find any problems with mismatched versions, which using the CDN script directly did not allow for.