### PR TITLE
US97068 Set searchInput to query value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: node
+node_js: 9
 script:
 - npm run test:lint
 - 'if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then polymer test --skip-plugin local; fi'

--- a/d2l-search-widget-behavior.html
+++ b/d2l-search-widget-behavior.html
@@ -123,10 +123,18 @@
 			}
 
 			// Siren parser can only parse entities, so make a fake one with the given action
-			var entity = {
+			var entity = window.D2L.Hypermedia.Siren.Parse({
 				actions: [ searchAction ]
-			};
-			this.set('_searchAction', window.D2L.Hypermedia.Siren.Parse(entity).actions[0]);
+			});
+			var parsedSearchAction = entity.actions[0];
+			this.set('_searchAction', parsedSearchAction);
+
+			var searchField = parsedSearchAction.getFieldByName(this.searchFieldName);
+			if (searchField && searchField.value) {
+				this.set('_searchInput', searchField.value);
+				// If we've applied a search, by default we want to show the clear button
+				this.set('_showClearIcon', true);
+			}
 		},
 
 		_onSearchInputChanged: function(newSearchString) {

--- a/test/d2l-search-widget.html
+++ b/test/d2l-search-widget.html
@@ -78,6 +78,13 @@
 				expect(searchWidget.searchFieldName).to.equal('query');
 			});
 
+			it('should set the search input to be the passed-in search field value, if applicable', function() {
+				entity.actions[0].fields[0].value = 'foo';
+				searchWidgetBasic.searchFieldName = 'query';
+				searchWidgetBasic.searchAction = entity.actions[0];
+				expect(searchWidgetBasic._searchInput).to.equal('foo');
+			});
+
 			it('should fire a d2l-search-widget-results-changed event when search completes', function(done) {
 				searchWidget._searchInput = 'foo';
 				var listener = function(e) {
@@ -122,6 +129,15 @@
 				it('should default to a search icon and correct ARIA label', function() {
 					expect(searchWidget.$$('button > d2l-icon').getAttribute('icon')).to.contain('search');
 					expect(searchWidget.$$('button').getAttribute('aria-label')).to.equal('Search');
+				});
+
+				it('should change to an X icon when a non-empty search query is passed in', function() {
+					entity.actions[0].fields[0].value = 'foo';
+					searchWidgetBasic.searchFieldName = 'query';
+					searchWidgetBasic.searchAction = entity.actions[0];
+					expect(searchWidgetBasic._showClearIcon).to.be.true;
+					expect(searchWidgetBasic.$$('button > d2l-icon').getAttribute('icon')).to.contain('close-default');
+					expect(searchWidgetBasic.$$('button').getAttribute('aria-label')).to.equal('Clear Search');
 				});
 
 				it('should change to an X icon when a search is done', function(done) {


### PR DESCRIPTION
If we pass in a searchAction that has a search/query field with a non-empty value, we should be setting the seach input value to that value. This is "more correct" behaviour than previously existed - if we're sending in a search action that already _has_ a query value, the presumption is that we're working with a collection that has already been searched - therefore, we should reflect this state in the search input field.

This also locks node to v9, as Travis has issues with v10 at the moment.